### PR TITLE
spelling: petitionssignatureform

### DIFF
--- a/petitionssignatureform.module
+++ b/petitionssignatureform.module
@@ -190,7 +190,7 @@ function petitionssignatureform_signature_form($form, &$form_state, $petition_id
     '#type' => 'submit',
     '#value' => t('Sign Now'),
     '#ajax' => array(
-      'callback' => 'petitionsignatureform_ajax_submit',
+      'callback' => 'petitionssignatureform_ajax_submit',
       'wrapper' => 'formwrapper',
       'method' => 'replace',
       'effect' => 'fade',
@@ -214,7 +214,7 @@ function petitionssignatureform_signature_form($form, &$form_state, $petition_id
  *
  * @see petitionssignatureform_signature_form()
  */
-function petitionsignatureform_ajax_submit($form, $form_state) {
+function petitionssignatureform_ajax_submit($form, $form_state) {
   petitionssignatureform_log_event('petitionssignatureform.form.submitted');
 
   // Validate the form.


### PR DESCRIPTION
Note: this is an API change. But I'm pretty sure it makes sense to make this change.
